### PR TITLE
Switch to "cryptography"

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -11,7 +11,7 @@ setup(
   license = 'MIT',
   install_requires=[
         'requests',
-        'pycrypto'
+        'cryptography'
       ],
   classifiers = [],
 )

--- a/simplepush/__init__.py
+++ b/simplepush/__init__.py
@@ -1,6 +1,8 @@
 import base64
-from Crypto import Random
-from Crypto.Cipher import AES
+import os
+from cryptography.hazmat.primitives import padding
+from cryptography.hazmat.primitives.ciphers import Cipher, algorithms, modes
+from cryptography.hazmat.backends import default_backend
 import hashlib
 import requests
 
@@ -56,7 +58,7 @@ def generate_payload(key, title, message, event=None, password=None, salt=None):
     return payload
 
 def generate_iv():
-    return Random.new().read(AES.block_size)
+    return os.urandom(algorithms.AES.block_size // 8)
 
 def generate_encryption_key(password, salt=None):
     if salt:
@@ -69,10 +71,8 @@ def generate_encryption_key(password, salt=None):
     return bytes(byte_str)
 
 def encrypt(encryption_key, iv, data):
-    BS = 16
-    pad = lambda s: s + (BS - len(s) % BS) * chr(BS - len(s) % BS) 
+    padder = padding.PKCS7(algorithms.AES.block_size).padder()
+    data = padder.update(data.encode()) + padder.finalize()
 
-    data = pad(data)
-
-    encrypted_data = AES.new(encryption_key, AES.MODE_CBC, IV=iv).encrypt(data)
-    return base64.urlsafe_b64encode(encrypted_data)
+    encryptor = Cipher(algorithms.AES(encryption_key), modes.CBC(iv), default_backend()).encryptor()
+    return base64.urlsafe_b64encode(encryptor.update(data) + encryptor.finalize())


### PR DESCRIPTION
Since "PyCrypto" is not maintained anymore, for compatibility and security, switch crypto api to "cryptography". 

Sources: 
https://github.com/dlitz/pycrypto/issues/173
https://github.com/paramiko/paramiko/pull/394
https://github.com/freedomofpress/securedrop/issues/1609