### PR TITLE
Allow sending non-ASCII messages

### DIFF
--- a/simplepush/__init__.py
+++ b/simplepush/__init__.py
@@ -112,7 +112,7 @@ def generate_encryption_key(password, salt=None):
 def encrypt(encryption_key, iv, data):
     """Encrypt the payload."""
     padder = padding.PKCS7(algorithms.AES.block_size).padder()
-    data = padder.update(data.encode()) + padder.finalize()
+    data = padder.update(data) + padder.finalize()
 
     encryptor = Cipher(algorithms.AES(encryption_key), modes.CBC(iv), default_backend()).encryptor()
     return base64.urlsafe_b64encode(encryptor.update(data) + encryptor.finalize())


### PR DESCRIPTION
This fixes transmission of non-ASCII *encrypted* messages. Otherwise we get an obvious exception here:

```
> 'ascii' codec can't decode byte 0xd0 in position 0: ordinal not in range(128)
```